### PR TITLE
Ensure C-Runtime is statically linked on Windows

### DIFF
--- a/Build.sln
+++ b/Build.sln
@@ -3,24 +3,26 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Build", "build\Build.csproj", "{8363325E-56EB-4B87-B170-C28237FB80CC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Build", "build\Build.csproj", "{8363325E-56EB-4B87-B170-C28237FB80CC}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MonoGame.Library.BuildScripts", "buildscripts\MonoGame.Library.BuildScripts.csproj", "{A5FA98AA-D51B-44AD-9CBF-F33F551E5A55}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{F9BD9E87-2B0B-4CB8-9C39-3FACD66E14AF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F9BD9E87-2B0B-4CB8-9C39-3FACD66E14AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F9BD9E87-2B0B-4CB8-9C39-3FACD66E14AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F9BD9E87-2B0B-4CB8-9C39-3FACD66E14AF}.Release|Any CPU.Build.0 = Release|Any CPU
 		{8363325E-56EB-4B87-B170-C28237FB80CC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8363325E-56EB-4B87-B170-C28237FB80CC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8363325E-56EB-4B87-B170-C28237FB80CC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8363325E-56EB-4B87-B170-C28237FB80CC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A5FA98AA-D51B-44AD-9CBF-F33F551E5A55}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A5FA98AA-D51B-44AD-9CBF-F33F551E5A55}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A5FA98AA-D51B-44AD-9CBF-F33F551E5A55}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A5FA98AA-D51B-44AD-9CBF-F33F551E5A55}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/build/BuildWindowsTask.cs
+++ b/build/BuildWindowsTask.cs
@@ -14,6 +14,8 @@ public sealed class BuildWindowsTask : FrostingTask<BuildContext>
         var buildDir = "sdl/build";
         context.CreateDirectory(buildDir);
         context.StartProcess("cmake", new ProcessSettings { WorkingDirectory = buildDir, Arguments = "-A x64 ../" });
+        //  Ensure statically linked
+        context.ReplaceTextInFiles(System.IO.Path.Combine(buildDir, "SDL2.vcxproj"), "MultiThreadedDLL", "MultiThreaded");
         context.StartProcess("msbuild", new ProcessSettings { WorkingDirectory = buildDir, Arguments = "SDL2.sln /p:Configuration=Release" });
 
         // Copy artifact

--- a/build/BuildWindowsTask.cs
+++ b/build/BuildWindowsTask.cs
@@ -13,9 +13,7 @@ public sealed class BuildWindowsTask : FrostingTask<BuildContext>
         // Build
         var buildDir = "sdl/build";
         context.CreateDirectory(buildDir);
-        context.StartProcess("cmake", new ProcessSettings { WorkingDirectory = buildDir, Arguments = "-A x64 ../" });
-        //  Ensure statically linked
-        context.ReplaceTextInFiles(System.IO.Path.Combine(buildDir, "SDL2.vcxproj"), "MultiThreadedDLL", "MultiThreaded");
+        context.StartProcess("cmake", new ProcessSettings { WorkingDirectory = buildDir, Arguments = "-A x64 -D CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded ../" });
         context.StartProcess("msbuild", new ProcessSettings { WorkingDirectory = buildDir, Arguments = "SDL2.sln /p:Configuration=Release" });
 
         // Copy artifact


### PR DESCRIPTION
SDL should normally not rely on the C runtime, just a double-check.