### PR TITLE
Include the SDL2 static lib

### DIFF
--- a/build/BuildWindowsTask.cs
+++ b/build/BuildWindowsTask.cs
@@ -14,10 +14,11 @@ public sealed class BuildWindowsTask : FrostingTask<BuildContext>
         var buildDir = "sdl/build";
         context.CreateDirectory(buildDir);
         context.StartProcess("cmake", new ProcessSettings { WorkingDirectory = buildDir, Arguments = "-A x64 -D CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded ../" });
-        context.StartProcess("msbuild", new ProcessSettings { WorkingDirectory = buildDir, Arguments = "SDL2.sln /p:Configuration=Release" });
+        context.StartProcess("msbuild", new ProcessSettings { WorkingDirectory = buildDir, Arguments = "SDL2.sln /p:Configuration=Release /p:Platform=x64" });
 
         // Copy artifact
         context.CreateDirectory(context.ArtifactsDir);
         context.CopyFile("sdl/build/Release/SDL2.dll", $"{context.ArtifactsDir}/SDL2.dll");
+        context.CopyFile("sdl/build/Release/SDL2-static.lib", $"{context.ArtifactsDir}/SDL2-static.lib");
     }
 }


### PR DESCRIPTION
For new MG native backend we need the static SDL2 lib for linking.

We've included it here as we transition towards the native backend in the future.
